### PR TITLE
fix: add SECURITY.md to clear Allstar issue

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,41 @@
+<img width=250px src="https://atsign.dev/assets/img/atPlatform_logo_gray.svg?sanitize=true">
+
+# Atsign Foundation Open Source Security Policies and Procedures
+
+This document outlines security procedures and general policies for the
+Atsign Foundation Open Source projects as found on
+https://github.com/atsign-foundation.
+
+  * [Reporting a Vulnerability](#reporting-a-vulnerability)
+  * [Disclosure Policy](#disclosure-policy)
+
+## Reporting a Vulnerability 
+
+The Atsign Foundation team and community take all security vulnerabilities
+seriously. Thank you for improving the security of our open source 
+software. We appreciate your efforts and responsible disclosure and will
+make every effort to acknowledge your contributions.
+
+Report security vulnerabilities by emailing the Atsign security team at:
+    
+    security@atsign.com
+
+The lead maintainer will acknowledge your email within 24 hours, and will
+send a more detailed response within 48 hours indicating the next steps in 
+handling your report. After the initial reply to your report, the security
+team will endeavor to keep you informed of the progress towards a fix and
+full announcement, and may ask for additional information or guidance.
+
+Please report security vulnerabilities in third-party modules to the person
+or team maintaining the module.
+
+## Disclosure Policy
+
+When the security team receives a security bug report, they will assign it
+to a primary handler. This person will coordinate the fix and release
+process, involving the following steps:
+
+  * Confirm the problem and determine the affected versions.
+  * Audit code to find any potential similar problems.
+  * Prepare fixes for all releases still under maintenance. These fixes
+    will be released as fast as possible to pub.dev where applicable.


### PR DESCRIPTION
Allstar has raised #1 about missing SECURITY.md, and it's just as easy to fix as it is to supress.

**- What I did**

Added SECURITY.md from archetype

**- How to verify it**

Allstar should automatically close issue

**- Description for the changelog**

fix: add SECURITY.md to clear Allstar issue